### PR TITLE
Use chunkName for translating

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -34,7 +34,7 @@ const generateRoutes = ({
   localizedRoutes.forEach(baseRoute => {
     locales.forEach((locale) => {
       const { component } = baseRoute
-      let { path, name, children } = baseRoute
+      let { path, name, children, chunkName } = baseRoute
       if (children) {
         children = generateRoutes({
           baseRoutes: children,
@@ -46,8 +46,8 @@ const generateRoutes = ({
         })
       }
       const { code } = locale
-      if (has(routesOptions, `${name}.${code}`)) {
-        path = routesOptions[name][code]
+      if (has(routesOptions, `${chunkName}.${code}`)) {
+        path = routesOptions[chunkName][code]
       }
       // Don't change path when current route is a child
       if (code !== defaultLocale && !isChild) {


### PR DESCRIPTION
Update to use chunkName such that nested routes can be translated.

Example:

pages
- parent.vue
- parent
 - index.vue
 - child.vue

In nuxt the parent route has no name and can not be translated in the current way.